### PR TITLE
fix(env/alfworld): the error success judgement in alfworld

### DIFF
--- a/ragen/env/alfworld_old/env.py
+++ b/ragen/env/alfworld_old/env.py
@@ -118,7 +118,6 @@ class AlfredTXTEnv(BaseLanguageBasedEnv):
             return f"Invalid action format: {action}", 0, False, {"action_is_effective": False, "action_is_valid": False, "success": False}
         
         obs, rewards, dones, infos = self.alfred_env.step([action])  # BatchEnv expects a list of commands
-        print("infos",infos)
         observation = obs[0]
         self.available_actions = infos["admissible_commands"][0]
         self.render_cache = observation


### PR DESCRIPTION
## Bug Fix
1. The 'done' will be true when execute 50 steps，and the code in alfworld/env.py Mistakenly treating 'done' as success.
2. The unavailable not be recognized in step function